### PR TITLE
Chaining doesn't work when handler returns undefined

### DIFF
--- a/lib/mock-promises.js
+++ b/lib/mock-promises.js
@@ -170,7 +170,7 @@
   };
 
   function resolvePromise(promise, value) {
-    if(isFunction(value.then)) {
+    if(value && isFunction(value.then)) {
       extend(promise, value);
     } else {
       extend(promise, {

--- a/spec/javascripts/mock-promises_spec.js
+++ b/spec/javascripts/mock-promises_spec.js
@@ -291,6 +291,25 @@ function itImplementsContracts(PromiseLibrary) {
         expect(promisedValue).toEqual('foo');
         expect(promisedChainedValue).toEqual('bar');
       });
+
+      it('chains correctly when a thenable returns undefined', function() {
+        promise = PromiseWrapper('foo');
+
+        var promisedValue = 'not resolved';
+        var promisedChainedValue = 'not resolved';
+
+        promise.then(function() {
+          promisedValue = 'foo';
+        }).then(function() {
+          promisedChainedValue = 'bar';
+        });
+
+        mockPromises.executeForPromise(promise);
+        mockPromises.iterateForPromise(promise);
+
+        expect(promisedValue).toEqual('foo');
+        expect(promisedChainedValue).toEqual('bar');
+      });
     });
 
     describe("executeForResolvedPromises", function() {


### PR DESCRIPTION
When a then() handler returns undefined, subsequent promises are not evaluated. The following test illustrates this (I used an assertion library with a slightly different syntax):

```javascript
it('chains correctly when a thenable returns undefined', function() {
    global.Promise = mockPromises.getMockPromise(global.Promise);
    mockPromises.reset();

    var hiThere;

    var promise = Promise.resolve('foo');
    promise.then(function() {
        hiThere = 'hi';
    }).then(function() {
        hiThere = 'hi there';
    });

    mockPromises.executeForPromise(promise);
    mockPromises.iterateForPromise(promise);

    expect(hiThere).to.equal('hi there');
});
```

The second promise is rejected with the error message "Cannot read property 'then' of undefined". The reason for this is the way `resolvePromise(promise, value)` checks whether the `value` parameter is a function: `isFunction(value.then)` should be rewritten as `value && isFunction(value.then)`.