### PR TITLE
Make sure that promise value is not removed after catch

### DIFF
--- a/lib/mock-promises.js
+++ b/lib/mock-promises.js
@@ -204,7 +204,8 @@ var extend = function(destination, source) {
         promise.then = fakeThen;
 
         promise.catch = function(errorHandler) {
-          return promise.then(function() {
+          return promise.then(function(value) {
+            return value;
           }, errorHandler);
         };
 


### PR DESCRIPTION
This makes sure that the following code works as expected with mock promises:

```
const myPromise = Promise.resolve()
  .then(() => {
    return myValue;
  })
  .catch(() => {
    ...
  });

myPromise
  .then((value) {
    console.log('value =', value);
  });
}); 
```

Without the change, the promise value gets lost in presence of the catch.