### PR TITLE
Suppress External Rejection Errors

### DIFF
--- a/lib/mock-promises.js
+++ b/lib/mock-promises.js
@@ -284,6 +284,10 @@ var extend = function(destination, source) {
           return contractsTracker[methodName].apply(contractsTracker, arguments);
         }
       });
+    
+    this.immediateResolve = function(number){
+      contractsTracker.immediateResolve(number);
+    };
 
     this.tick = function(count) {
       if(!count) count = 1;
@@ -387,11 +391,21 @@ var extend = function(destination, source) {
   var ContractsTracker = function() {
     var contracts = [];
     var id = 0;
+    var immediate = 0;
     this.reset = function() {
       contracts = [];
     };
 
+    this.immediateResolve = function(number) {
+      immediate = number;
+    };
+
     this.add = function(options) {
+      if (immediate) {
+        (new Contract(options)).execute();
+        immediate -= 1;
+        return;
+      }
       options.id = id;
       id++;
       contracts.push(new Contract(options));

--- a/lib/mock-promises.js
+++ b/lib/mock-promises.js
@@ -233,6 +233,7 @@ var extend = function(destination, source) {
         progressHandler: arguments[2],
         thenPromise: thenPromise
       });
+      promise.suppressUnhandledRejections();
       return thenPromise;
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-promises",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": "Charles Hansen <chansen87@gmail.com>",
   "license": "MIT",
   "description": "Library for mocking promises in specs",


### PR DESCRIPTION
Bluebird/Native Promises etc. will check for unhandled exceptions. With mock-promises the control over that is best handled here.